### PR TITLE
Feature/mlflow integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional MLflow export integration mirroring the existing W&B exporter: `stormlog.mlflow_integration` with `--mlflow*` CLI flags on `gpumemprof`, `jaxmemprof`, and `tfmemprof` (`track` and `diagnose`), logging session metrics/tags, alert and timeline tables, tracking dashboard HTML, matplotlib plots, attribution previews, and output/telemetry/attribution artifacts. Install with `pip install 'stormlog[mlflow]'`.
 - Launch QA scenario modules under `examples/scenarios/` for CPU telemetry, MPS telemetry, OOM flight recorder coverage, and TensorFlow end-to-end telemetry/diagnose checks.
 - Capability matrix orchestrator (`python -m examples.cli.capability_matrix`) with smoke/full modes, target selection (`auto|cpu|mps|both`), OOM mode controls, and machine-readable reports.
 - Scenario smoke tests (`tests/test_examples_scenarios.py`) and updated TUI pilot coverage for launch quick actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optional MLflow export integration mirroring the existing W&B exporter: `stormlog.mlflow_integration` with `--mlflow*` CLI flags on `gpumemprof`, `jaxmemprof`, and `tfmemprof` (`track` and `diagnose`), logging session metrics/tags, alert and timeline tables, tracking dashboard HTML, matplotlib plots, attribution previews, and output/telemetry/attribution artifacts. Install with `pip install 'stormlog[mlflow]'`.
 - Launch QA scenario modules under `examples/scenarios/` for CPU telemetry, MPS telemetry, OOM flight recorder coverage, and TensorFlow end-to-end telemetry/diagnose checks.
 - Capability matrix orchestrator (`python -m examples.cli.capability_matrix`) with smoke/full modes, target selection (`auto|cpu|mps|both`), OOM mode controls, and machine-readable reports.
 - Scenario smoke tests (`tests/test_examples_scenarios.py`) and updated TUI pilot coverage for launch quick actions.

--- a/docs/cookbook/pytorch.md
+++ b/docs/cookbook/pytorch.md
@@ -69,6 +69,15 @@ This recipe was validated from a source checkout against a JarvisLabs L4
 container using `examples.scenarios.wandb_training_smoke` in `wandb offline`
 mode.
 
+> **Prefer MLflow?** Stormlog also ships an optional MLflow exporter with the
+> same surface as W&B (metrics/tags, alert and timeline tables, dashboard HTML,
+> plots, attribution previews, and artifacts). Install with
+> `pip install 'stormlog[mlflow]'` and pass `--mlflow`,
+> `--mlflow-experiment <name>`, `--mlflow-run-name <name>`,
+> `--mlflow-tracking-uri file:./mlruns` (offline mode), and
+> `--mlflow-log-artifacts` to any `gpumemprof`, `jaxmemprof`, or `tfmemprof`
+> `track`/`diagnose` command instead of the `--wandb*` flags below.
+
 Use it when you need one short real training run that proves:
 
 - CUDA training is actually happening

--- a/docs/cookbook/pytorch.md
+++ b/docs/cookbook/pytorch.md
@@ -74,7 +74,7 @@ mode.
 > plots, attribution previews, and artifacts). Install with
 > `pip install 'stormlog[mlflow]'` and pass `--mlflow`,
 > `--mlflow-experiment <name>`, `--mlflow-run-name <name>`,
-> `--mlflow-tracking-uri file:./mlruns` (offline mode), and
+> `--mlflow-tracking-uri sqlite:///mlflow.db` (offline mode), and
 > `--mlflow-log-artifacts` to any `gpumemprof`, `jaxmemprof`, or `tfmemprof`
 > `track`/`diagnose` command instead of the `--wandb*` flags below.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -129,6 +129,25 @@ python -m examples.scenarios.wandb_training_smoke --device cuda --wandb-mode off
 python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 -m examples.scenarios.torchrun_ddp_reference
 ```
 
+### Exporting to MLflow
+
+The `track` and `diagnose` commands can export their summaries, tables,
+dashboards, and artifacts to MLflow instead of W&B using the `--mlflow*` flags
+(install with `pip install 'stormlog[mlflow]'`):
+
+```bash
+gpumemprof track --duration 60 --mlflow \
+  --mlflow-experiment stormlog-smoke \
+  --mlflow-tracking-uri file:./mlruns \
+  --mlflow-run-name my-run \
+  --mlflow-log-artifacts
+gpumemprof diagnose --mlflow --mlflow-experiment stormlog-smoke
+```
+
+`--mlflow-tracking-uri file:./mlruns` is the offline equivalent of
+`--wandb-mode offline`; omit it to log to the server configured by the
+`MLFLOW_TRACKING_URI` environment variable.
+
 ### When to use them
 
 - `cpu_telemetry_scenario`: validate CPU-only telemetry export
@@ -137,7 +156,8 @@ python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 -m examples.scenar
 - `tf_end_to_end_scenario`: validate TensorFlow monitor, track, analyze, and diagnose flow together
 - `wandb_training_smoke`: run a short real PyTorch training loop that writes a
   summary bundle, an append-only sink, offline W&B files, and structured phase
-  boundaries you can reload in `gpumemprof analyze` and the TUI
+  boundaries you can reload in `gpumemprof analyze` and the TUI (the same
+  outputs can be exported to MLflow with `--mlflow*` flags on the CLI)
 - `torchrun_ddp_reference`: run a reference single-node DDP training job
   derived from the official PyTorch `torchrun` tutorial pattern, with one
   telemetry sink per rank and a shared distributed summary

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -138,15 +138,17 @@ dashboards, and artifacts to MLflow instead of W&B using the `--mlflow*` flags
 ```bash
 gpumemprof track --duration 60 --mlflow \
   --mlflow-experiment stormlog-smoke \
-  --mlflow-tracking-uri file:./mlruns \
+  --mlflow-tracking-uri sqlite:///mlflow.db \
   --mlflow-run-name my-run \
   --mlflow-log-artifacts
 gpumemprof diagnose --mlflow --mlflow-experiment stormlog-smoke
 ```
 
-`--mlflow-tracking-uri file:./mlruns` is the offline equivalent of
+`--mlflow-tracking-uri sqlite:///mlflow.db` is the offline equivalent of
 `--wandb-mode offline`; omit it to log to the server configured by the
-`MLFLOW_TRACKING_URI` environment variable.
+`MLFLOW_TRACKING_URI` environment variable. Note that a local `file:./mlruns`
+URI requires `MLFLOW_ALLOW_FILE_STORE=true` on MLflow >= 3, where the
+filesystem tracking backend is in maintenance mode.
 
 ### When to use them
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -131,7 +131,7 @@ Optional MLflow export check (requires `pip install 'stormlog[mlflow]'`):
 
 ```bash
 gpumemprof track --duration 10 --interval 0.5 --output track.json --format json \
-  --mlflow --mlflow-experiment stormlog-smoke --mlflow-tracking-uri file:./mlruns
+  --mlflow --mlflow-experiment stormlog-smoke --mlflow-tracking-uri sqlite:///mlflow.db
 ```
 
 ## CI behavior in this repo

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -127,6 +127,13 @@ tfmemprof info
 tfmemprof diagnose --duration 0 --output ./tf_diag
 ```
 
+Optional MLflow export check (requires `pip install 'stormlog[mlflow]'`):
+
+```bash
+gpumemprof track --duration 10 --interval 0.5 --output track.json --format json \
+  --mlflow --mlflow-experiment stormlog-smoke --mlflow-tracking-uri file:./mlruns
+```
+
 ## CI behavior in this repo
 
 The current CI workflow at `.github/workflows/ci.yml` runs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ infer-tokenizers = [
 wandb = [
     "wandb>=0.19.0",
 ]
+mlflow = [
+    "mlflow>=2.4.0",
+]
 jax = [
     "jax>=0.4.20",
     "protobuf>=6.31.1",
@@ -81,6 +84,7 @@ all = [
     "textual>=0.57.0",
     "pyfiglet>=1.0.2",
     "wandb>=0.19.0",
+    "mlflow>=2.4.0",
     "jax>=0.4.20",
     "protobuf>=6.31.1",
 ]
@@ -248,6 +252,8 @@ module = [
     "rich.*",
     "wandb",
     "wandb.*",
+    "mlflow",
+    "mlflow.*",
     "torchvision",
     "torchvision.*",
 ]

--- a/stormlog/_mlflow/__init__.py
+++ b/stormlog/_mlflow/__init__.py
@@ -1,0 +1,1 @@
+"""MLflow export internals (mirror of the optional W&B exporter)."""

--- a/stormlog/_mlflow/attribution.py
+++ b/stormlog/_mlflow/attribution.py
@@ -1,0 +1,79 @@
+"""Attribution-specific MLflow export helpers (mirror of the W&B exporter).
+
+The HTML preview rendering and tensor-table extraction are backend-agnostic and
+shared with the W&B exporter (see ``stormlog._wandb.attribution``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from .._wandb.attribution import (
+    build_attribution_preview_html,
+    tensor_attribution_rows,
+)
+from .._wandb.core import read_json_if_exists
+from ..cuda_native_debug import (
+    ALLOCATION_ATTRIBUTION_FILENAME,
+    DEBUG_METADATA_FILENAME,
+    TENSOR_ATTRIBUTION_FILENAME,
+    TRACE_HTML_ANNOTATED_FILENAME,
+    TRACE_HTML_FILENAME,
+)
+
+
+def log_attribution_outputs(
+    mlflow: Any,
+    *,
+    root: Path,
+    session_slug: str,
+    allow_artifact_logging: bool = False,
+) -> dict[str, Any]:
+    summary_fields: dict[str, Any] = {}
+    files_to_attach = [
+        root / TRACE_HTML_ANNOTATED_FILENAME,
+        root / TRACE_HTML_FILENAME,
+        root / TENSOR_ATTRIBUTION_FILENAME,
+        root / ALLOCATION_ATTRIBUTION_FILENAME,
+        root / DEBUG_METADATA_FILENAME,
+    ]
+    existing_files = [
+        path for path in files_to_attach if path.exists() and path.is_file()
+    ]
+
+    if allow_artifact_logging and existing_files:
+        for path in existing_files:
+            mlflow.log_artifact(
+                local_path=str(path),
+                artifact_path=f"stormlog-attribution-{session_slug}",
+            )
+
+    html_path = root / TRACE_HTML_ANNOTATED_FILENAME
+    if html_path.exists():
+        preview_html = build_attribution_preview_html(root)
+        mlflow.log_text(preview_html, artifact_file="stormlog_attribution_preview.html")
+        summary_fields["stormlog_attribution_html_file"] = html_path.name
+
+    tensor_rows = tensor_attribution_rows(root / TENSOR_ATTRIBUTION_FILENAME)
+    if tensor_rows:
+        mlflow.log_table(
+            data={
+                "name": [str(row[0]) for row in tensor_rows[:200]],
+                "storage_ptr": [str(row[1]) for row in tensor_rows[:200]],
+                "tensor_count": [int(row[2]) for row in tensor_rows[:200]],
+                "total_size_bytes": [int(row[3]) for row in tensor_rows[:200]],
+                "shape": [str(row[4]) for row in tensor_rows[:200]],
+                "dtype": [str(row[5]) for row in tensor_rows[:200]],
+            },
+            artifact_file="stormlog_tensor_attribution.json",
+        )
+        summary_fields["stormlog_tensor_attribution_rows"] = len(tensor_rows)
+
+    metadata = read_json_if_exists(root / DEBUG_METADATA_FILENAME)
+    if isinstance(metadata, Mapping):
+        history_recorded = metadata.get("history_recorded")
+        if isinstance(history_recorded, bool):
+            summary_fields["stormlog_attribution_history_recorded"] = history_recorded
+
+    return summary_fields

--- a/stormlog/_mlflow/core.py
+++ b/stormlog/_mlflow/core.py
@@ -9,6 +9,7 @@ summary/metric/tag writing.
 
 from __future__ import annotations
 
+import sys
 import tempfile
 from dataclasses import dataclass
 from importlib import import_module
@@ -21,6 +22,10 @@ from ..session import SessionSummary
 MLFLOW_INSTALL_GUIDANCE = (
     "MLflow integration requires optional dependencies. "
     "Install with `pip install 'stormlog[mlflow]'`."
+)
+
+_IDENTITY_TAG_KEYS = frozenset(
+    {"stormlog_rank", "stormlog_local_rank", "stormlog_world_size"}
 )
 
 
@@ -143,15 +148,25 @@ def resolve_run(
 
     if config.tracking_uri is not None:
         mlflow.set_tracking_uri(config.tracking_uri)
+        if config.tracking_uri.startswith("file:"):
+            print(
+                "Hint: a file: tracking URI requires MLFLOW_ALLOW_FILE_STORE=true "
+                "on MLflow >= 3; consider sqlite:///mlflow.db for offline storage.",
+                file=sys.stderr,
+            )
 
     experiment = config.experiment or "stormlog"
     mlflow.set_experiment(experiment)
 
-    start_kwargs: dict[str, Any] = {
-        "run_name": config.run_name or _default_run_name(command_name, session_summary),
-    }
+    start_kwargs: dict[str, Any] = {}
     if config.run_id is not None:
         start_kwargs["run_id"] = config.run_id
+        if config.run_name is not None:
+            start_kwargs["run_name"] = config.run_name
+    else:
+        start_kwargs["run_name"] = config.run_name or _default_run_name(
+            command_name, session_summary
+        )
 
     run = mlflow.start_run(**start_kwargs)
     tags: dict[str, Any] = dict(session_summary_fields(session_summary))
@@ -171,9 +186,11 @@ def update_summary(mlflow: Any, payload: Mapping[str, Any]) -> None:
     for key, value in payload.items():
         if value is None:
             continue
-        if isinstance(value, bool):
+        if key in _IDENTITY_TAG_KEYS:
+            mlflow.set_tag(key, str(value))
+        elif isinstance(value, bool):
             mlflow.set_tag(key, "true" if value else "false")
-        elif isinstance(value, (int, float)) and not isinstance(value, complex):
+        elif isinstance(value, (int, float)):
             mlflow.log_metric(key, float(value))
         else:
             mlflow.set_tag(key, str(value))

--- a/stormlog/_mlflow/core.py
+++ b/stormlog/_mlflow/core.py
@@ -1,0 +1,232 @@
+"""Core helpers shared by Stormlog's optional MLflow exporter.
+
+The W&B exporter modules host a number of backend-agnostic helpers (session
+summary fields, path coercion, JSON reads).  The MLflow exporter reuses those
+pure helpers so both integrations stay in sync; this module only implements the
+MLflow-specific surface: config, CLI flags, import guard, run lifecycle, and
+summary/metric/tag writing.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Mapping
+
+from .._wandb.core import default_group, session_summary_fields
+from ..session import SessionSummary
+
+MLFLOW_INSTALL_GUIDANCE = (
+    "MLflow integration requires optional dependencies. "
+    "Install with `pip install 'stormlog[mlflow]'`."
+)
+
+
+@dataclass(frozen=True)
+class MlflowExportConfig:
+    """Runtime configuration for optional MLflow exports."""
+
+    enabled: bool = False
+    tracking_uri: str | None = None
+    experiment: str | None = None
+    run_id: str | None = None
+    run_name: str | None = None
+    group: str | None = None
+    job_type: str | None = None
+    log_tables: bool = True
+    log_artifacts: bool = False
+    log_attribution: bool = False
+
+
+def mlflow_config_from_namespace(args: Any) -> MlflowExportConfig:
+    """Build an MLflow export config from CLI args or a similar namespace."""
+    return MlflowExportConfig(
+        enabled=bool(getattr(args, "mlflow", False)),
+        tracking_uri=_normalized_optional_string(
+            getattr(args, "mlflow_tracking_uri", None)
+        ),
+        experiment=_normalized_optional_string(
+            getattr(args, "mlflow_experiment", None)
+        ),
+        run_id=_normalized_optional_string(getattr(args, "mlflow_run_id", None)),
+        run_name=_normalized_optional_string(getattr(args, "mlflow_run_name", None)),
+        group=_normalized_optional_string(getattr(args, "mlflow_group", None)),
+        job_type=_normalized_optional_string(getattr(args, "mlflow_job_type", None)),
+        log_artifacts=bool(getattr(args, "mlflow_log_artifacts", False)),
+        log_attribution=bool(getattr(args, "mlflow_log_attribution", False)),
+    )
+
+
+def add_mlflow_arguments(parser: Any) -> None:
+    """Attach shared optional MLflow flags to a CLI parser."""
+    parser.add_argument(
+        "--mlflow",
+        action="store_true",
+        help="Log Stormlog summaries to MLflow",
+    )
+    parser.add_argument(
+        "--mlflow-tracking-uri",
+        type=str,
+        default=None,
+        help="MLflow tracking server URI or local file path (default: MLFLOW_TRACKING_URI env)",
+    )
+    parser.add_argument(
+        "--mlflow-experiment",
+        type=str,
+        default=None,
+        help="MLflow experiment name (default: stormlog)",
+    )
+    parser.add_argument(
+        "--mlflow-run-id",
+        type=str,
+        default=None,
+        help="Existing MLflow run id to resume or attach to",
+    )
+    parser.add_argument(
+        "--mlflow-run-name",
+        type=str,
+        default=None,
+        help="Explicit MLflow run name",
+    )
+    parser.add_argument(
+        "--mlflow-group",
+        type=str,
+        default=None,
+        help="MLflow group tag override (default: Stormlog job id)",
+    )
+    parser.add_argument(
+        "--mlflow-job-type",
+        type=str,
+        default=None,
+        help="MLflow job type tag override (default: Stormlog command name)",
+    )
+    parser.add_argument(
+        "--mlflow-log-artifacts",
+        action="store_true",
+        help="Upload Stormlog output bundles as MLflow artifacts",
+    )
+    parser.add_argument(
+        "--mlflow-log-attribution",
+        action="store_true",
+        help="Log attribution HTML and top offenders to MLflow when available",
+    )
+
+
+def ensure_mlflow_available(config: MlflowExportConfig) -> None:
+    """Fail fast when the MLflow feature is enabled without dependencies installed."""
+    if config.enabled:
+        import_mlflow()
+
+
+def import_mlflow() -> Any:
+    try:
+        return import_module("mlflow")
+    except ModuleNotFoundError as exc:
+        if exc.name == "mlflow":
+            raise ImportError(MLFLOW_INSTALL_GUIDANCE) from exc
+        raise
+
+
+def resolve_run(
+    config: MlflowExportConfig,
+    *,
+    command_name: str,
+    session_summary: SessionSummary | None,
+) -> tuple[Any, Any, bool]:
+    """Return (mlflow module, run object, managed) like the W&B exporter."""
+    mlflow = import_mlflow()
+    active_run = mlflow.active_run()
+    if active_run is not None:
+        return mlflow, active_run, False
+
+    if config.tracking_uri is not None:
+        mlflow.set_tracking_uri(config.tracking_uri)
+
+    experiment = config.experiment or "stormlog"
+    mlflow.set_experiment(experiment)
+
+    start_kwargs: dict[str, Any] = {
+        "run_name": config.run_name or _default_run_name(command_name, session_summary),
+    }
+    if config.run_id is not None:
+        start_kwargs["run_id"] = config.run_id
+
+    run = mlflow.start_run(**start_kwargs)
+    tags: dict[str, Any] = dict(session_summary_fields(session_summary))
+    tags["stormlog_command"] = command_name
+    group = config.group or default_group(session_summary)
+    if group is not None:
+        tags["stormlog_group"] = group
+    tags["stormlog_job_type"] = config.job_type or command_name
+    mlflow.set_tags(tags)
+    return mlflow, run, True
+
+
+def update_summary(mlflow: Any, payload: Mapping[str, Any]) -> None:
+    """Mirror ``wandb`` summary updates: numbers become metrics, the rest tags."""
+    if not payload:
+        return
+    for key, value in payload.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            mlflow.set_tag(key, "true" if value else "false")
+        elif isinstance(value, (int, float)) and not isinstance(value, complex):
+            mlflow.log_metric(key, float(value))
+        else:
+            mlflow.set_tag(key, str(value))
+
+
+def log_file_artifact(
+    mlflow: Any,
+    *,
+    artifact_path: str,
+    path: Path,
+) -> None:
+    mlflow.log_artifact(local_path=str(path), artifact_path=artifact_path)
+
+
+def log_directory_artifact(
+    mlflow: Any,
+    *,
+    artifact_path: str,
+    path: Path,
+) -> None:
+    mlflow.log_artifacts(local_dir=str(path), artifact_path=artifact_path)
+
+
+def materialize_html_file(
+    *,
+    html_text: str,
+    file_name: str,
+    output_root: Path | None,
+) -> Path:
+    if output_root is not None:
+        output_root.mkdir(parents=True, exist_ok=True)
+        target_path = output_root / file_name
+        target_path.write_text(html_text, encoding="utf-8")
+        return target_path
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="stormlog-mlflow-"))
+    target_path = temp_dir / file_name
+    target_path.write_text(html_text, encoding="utf-8")
+    target_path.chmod(0o600)
+    return target_path
+
+
+def _default_run_name(
+    command_name: str,
+    session_summary: SessionSummary | None,
+) -> str:
+    if session_summary is None:
+        return command_name
+    return f"{command_name}-{session_summary.session_id[:8]}"
+
+
+def _normalized_optional_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/stormlog/_mlflow/diagnose.py
+++ b/stormlog/_mlflow/diagnose.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 from .._wandb.core import (
     read_json_if_exists,
     session_slug,
+    session_summary_fields,
     session_summary_from_manifest,
 )
 from .._wandb.diagnose import diagnose_metrics, diagnose_summary_fields
@@ -16,7 +17,6 @@ from .core import (
     MlflowExportConfig,
     log_directory_artifact,
     resolve_run,
-    session_summary_fields,
     update_summary,
 )
 

--- a/stormlog/_mlflow/diagnose.py
+++ b/stormlog/_mlflow/diagnose.py
@@ -1,0 +1,97 @@
+"""Diagnose-bundle MLflow export helpers (mirror of the W&B exporter)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from .._wandb.core import (
+    read_json_if_exists,
+    session_slug,
+    session_summary_from_manifest,
+)
+from .._wandb.diagnose import diagnose_metrics, diagnose_summary_fields
+from .attribution import log_attribution_outputs
+from .core import (
+    MlflowExportConfig,
+    log_directory_artifact,
+    resolve_run,
+    session_summary_fields,
+    update_summary,
+)
+
+
+def export_diagnose_bundle_to_mlflow(
+    config: MlflowExportConfig,
+    *,
+    command_name: str,
+    artifact_dir: str | Path,
+) -> None:
+    """Export one diagnose bundle directory to MLflow."""
+    if not config.enabled:
+        return
+
+    bundle_dir = Path(artifact_dir)
+    if not bundle_dir.exists() or not bundle_dir.is_dir():
+        raise FileNotFoundError(
+            f"Diagnose artifact directory not found: {artifact_dir}"
+        )
+
+    manifest = read_json_if_exists(bundle_dir / "manifest.json")
+    diagnostic_summary = read_json_if_exists(bundle_dir / "diagnostic_summary.json")
+    session_summary = session_summary_from_manifest(manifest)
+
+    mlflow, run, managed = resolve_run(
+        config,
+        command_name=command_name,
+        session_summary=session_summary,
+    )
+    try:
+        update_summary(
+            mlflow,
+            diagnose_metrics(diagnostic_summary, manifest)
+            | session_summary_fields(session_summary)
+            | diagnose_summary_fields(bundle_dir, manifest),
+        )
+
+        if config.log_tables:
+            log_suggestions_table(mlflow, diagnostic_summary)
+
+        if config.log_artifacts:
+            log_directory_artifact(
+                mlflow,
+                artifact_path=f"stormlog-diagnose-{session_slug(session_summary)}",
+                path=bundle_dir,
+            )
+
+        if config.log_attribution:
+            update_summary(
+                mlflow,
+                log_attribution_outputs(
+                    mlflow,
+                    root=bundle_dir,
+                    session_slug=session_slug(session_summary),
+                    allow_artifact_logging=config.log_artifacts,
+                ),
+            )
+    finally:
+        if managed:
+            mlflow.end_run()
+
+
+def log_suggestions_table(
+    mlflow: Any,
+    diagnostic_summary: Mapping[str, Any] | None,
+) -> None:
+    if not isinstance(diagnostic_summary, Mapping):
+        return
+    suggestions = diagnostic_summary.get("suggestions")
+    if not isinstance(suggestions, list) or not suggestions:
+        return
+    mlflow.log_table(
+        data={
+            "index": list(range(1, len(suggestions) + 1)),
+            "suggestion": [str(suggestion) for suggestion in suggestions],
+        },
+        artifact_file="stormlog_diagnostic_suggestions.json",
+    )

--- a/stormlog/_mlflow/tracking.py
+++ b/stormlog/_mlflow/tracking.py
@@ -1,0 +1,306 @@
+"""Tracking-session MLflow export helpers.
+
+Mirrors ``stormlog._wandb.tracking`` for MLflow.  The pure timeline/metric
+helpers live in the W&B exporter modules and are backend-agnostic, so they are
+reused here to keep both integrations in sync.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .._wandb.core import (
+    coerce_existing_dir,
+    coerce_existing_file,
+    session_slug,
+    session_summary_fields,
+)
+from .._wandb.dashboard import tracking_dashboard_html
+from .._wandb.tracking import (
+    _ALERT_EVENT_TYPES,
+    _memory_plot_series,
+    _series_for_plot,
+    _tracking_dashboard_root,
+    event_int_value,
+    event_timestamp_seconds,
+    event_value,
+    tracking_metrics,
+    tracking_summary_fields,
+    tracking_timeline_rows,
+)
+from ..session import SessionSummary
+from .attribution import log_attribution_outputs
+from .core import (
+    MlflowExportConfig,
+    log_directory_artifact,
+    log_file_artifact,
+    materialize_html_file,
+    resolve_run,
+    update_summary,
+)
+
+
+def export_tracking_run_to_mlflow(
+    config: MlflowExportConfig,
+    *,
+    command_name: str,
+    session_summary: SessionSummary | None,
+    stats: Mapping[str, Any],
+    events: Sequence[Any],
+    output_path: str | Path | None = None,
+    telemetry_sink_dir: str | Path | None = None,
+    oom_dump_path: str | Path | None = None,
+    attribution_bundle_dir: str | Path | None = None,
+) -> None:
+    """Export one completed tracking session to MLflow."""
+    if not config.enabled:
+        return
+
+    timeline_rows = tracking_timeline_rows(events)
+    mlflow, run, managed = resolve_run(
+        config,
+        command_name=command_name,
+        session_summary=session_summary,
+    )
+    safe_session = session_slug(session_summary)
+    output_file = coerce_existing_file(output_path)
+    sink_dir = coerce_existing_dir(telemetry_sink_dir)
+    oom_dir = coerce_existing_dir(oom_dump_path)
+    attribution_dir = coerce_existing_dir(attribution_bundle_dir) or oom_dir
+
+    try:
+        update_summary(
+            mlflow,
+            tracking_metrics(stats)
+            | {"stormlog_chart_point_count": len(timeline_rows)}
+            | session_summary_fields(session_summary)
+            | tracking_summary_fields(stats, output_path=output_path),
+        )
+
+        log_tracking_time_series(mlflow, timeline_rows)
+
+        if config.log_tables:
+            log_alerts_table(mlflow, events)
+            update_summary(
+                mlflow,
+                log_tracking_visualizations(
+                    mlflow,
+                    timeline_rows,
+                    session_slug=safe_session,
+                    dashboard_root=_tracking_dashboard_root(output_file, sink_dir),
+                    allow_artifact_logging=config.log_artifacts,
+                ),
+            )
+
+        if config.log_artifacts:
+            if output_file is not None:
+                log_file_artifact(
+                    mlflow,
+                    artifact_path=f"stormlog-track-output-{safe_session}",
+                    path=output_file,
+                )
+
+            if sink_dir is not None:
+                log_directory_artifact(
+                    mlflow,
+                    artifact_path=f"stormlog-telemetry-sink-{safe_session}",
+                    path=sink_dir,
+                )
+
+            if oom_dir is not None:
+                log_directory_artifact(
+                    mlflow,
+                    artifact_path=f"stormlog-oom-dump-{safe_session}",
+                    path=oom_dir,
+                )
+
+            if (
+                attribution_bundle_dir is not None
+                and attribution_dir is not None
+                and attribution_dir != oom_dir
+            ):
+                log_directory_artifact(
+                    mlflow,
+                    artifact_path=f"stormlog-attribution-bundle-{safe_session}",
+                    path=attribution_dir,
+                )
+
+        if config.log_attribution and attribution_dir is not None:
+            update_summary(
+                mlflow,
+                log_attribution_outputs(
+                    mlflow,
+                    root=attribution_dir,
+                    session_slug=safe_session,
+                    allow_artifact_logging=config.log_artifacts,
+                ),
+            )
+    finally:
+        if managed:
+            mlflow.end_run()
+
+
+def log_alerts_table(mlflow: Any, events: Sequence[Any]) -> None:
+    rows: list[list[Any]] = []
+    for event in events:
+        event_type = event_value(event, "event_type") or event_value(event, "type")
+        if event_type not in _ALERT_EVENT_TYPES:
+            continue
+        rows.append(
+            [
+                event_timestamp_seconds(event),
+                event_type,
+                event_value(event, "context"),
+                event_int_value(event, "memory_allocated", "allocator_allocated_bytes"),
+                event_int_value(event, "memory_reserved", "allocator_reserved_bytes"),
+                event_int_value(event, "memory_change", "allocator_change_bytes"),
+                event_value(event, "job_id"),
+                event_value(event, "rank"),
+            ]
+        )
+    if not rows:
+        return
+    columns = [
+        "timestamp_s",
+        "event_type",
+        "context",
+        "memory_allocated_bytes",
+        "memory_reserved_bytes",
+        "memory_change_bytes",
+        "job_id",
+        "rank",
+    ]
+    mlflow.log_table(
+        data=_rows_as_columns(columns, rows[-250:]),
+        artifact_file="stormlog_alerts.json",
+    )
+
+
+def log_tracking_time_series(mlflow: Any, rows: Sequence[Mapping[str, Any]]) -> None:
+    for row in rows:
+        payload = {
+            "stormlog_timeline_elapsed_seconds": row["elapsed_seconds"],
+            "stormlog_timeline_allocated_bytes": row["allocated_bytes"],
+            "stormlog_timeline_reserved_bytes": row["reserved_bytes"],
+            "stormlog_timeline_change_bytes": row["change_bytes"],
+            "stormlog_timeline_device_used_bytes": row["device_used_bytes"],
+            "stormlog_timeline_utilization_percent": row["utilization_percent"],
+        }
+        filtered_payload = {
+            key: value for key, value in payload.items() if value is not None
+        }
+        if filtered_payload:
+            mlflow.log_metrics(filtered_payload, step=int(row["sample_index"]))
+
+
+def log_tracking_visualizations(
+    mlflow: Any,
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    session_slug: str,
+    dashboard_root: Path | None,
+    allow_artifact_logging: bool,
+) -> dict[str, Any]:
+    if not rows:
+        return {}
+
+    columns = [
+        "sample_index",
+        "elapsed_seconds",
+        "event_type",
+        "memory_allocated_bytes",
+        "memory_reserved_bytes",
+        "memory_change_bytes",
+        "device_used_bytes",
+        "utilization_percent",
+        "context",
+        "rank",
+    ]
+    data_rows = [
+        [
+            row["sample_index"],
+            row["elapsed_seconds"],
+            row["event_type"],
+            row["allocated_bytes"],
+            row["reserved_bytes"],
+            row["change_bytes"],
+            row["device_used_bytes"],
+            row["utilization_percent"],
+            row["context"],
+            row["rank"],
+        ]
+        for row in rows
+    ]
+    mlflow.log_table(
+        data=_rows_as_columns(columns, data_rows),
+        artifact_file="stormlog_memory_timeline.json",
+    )
+
+    log_memory_plots(mlflow, rows)
+
+    dashboard_html = tracking_dashboard_html(rows, alert_event_types=_ALERT_EVENT_TYPES)
+    mlflow.log_text(dashboard_html, artifact_file="stormlog_tracking_dashboard.html")
+
+    if not allow_artifact_logging:
+        return {}
+
+    dashboard_path = materialize_html_file(
+        html_text=dashboard_html,
+        file_name="stormlog_tracking_dashboard.html",
+        output_root=dashboard_root,
+    )
+    mlflow.log_artifact(
+        local_path=str(dashboard_path),
+        artifact_path=f"stormlog-tracking-dashboard-{session_slug}",
+    )
+    return {"stormlog_tracking_dashboard_file": dashboard_path.name}
+
+
+def log_memory_plots(mlflow: Any, rows: Sequence[Mapping[str, Any]]) -> None:
+    """Log matplotlib figures when matplotlib is available; otherwise skip."""
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception:
+        return
+
+    elapsed = [float(row["elapsed_seconds"]) for row in rows]
+
+    keys, series = _memory_plot_series(rows)
+    if keys:
+        figure = plt.figure(figsize=(10, 4))
+        for label, values in zip(keys, series):
+            plt.plot(elapsed, values, label=label)
+        plt.xlabel("Elapsed Seconds")
+        plt.ylabel("Bytes")
+        plt.title("Stormlog Memory Timeline")
+        plt.legend()
+        plt.tight_layout()
+        mlflow.log_figure(figure, artifact_file="stormlog_memory_timeline.png")
+        plt.close(figure)
+
+    utilization_series = _series_for_plot(rows, "utilization_percent")
+    if any(not _is_missing(value) for value in utilization_series):
+        figure = plt.figure(figsize=(10, 4))
+        plt.plot(elapsed, utilization_series)
+        plt.xlabel("Elapsed Seconds")
+        plt.ylabel("Utilization (%)")
+        plt.title("Stormlog Memory Utilization")
+        plt.tight_layout()
+        mlflow.log_figure(figure, artifact_file="stormlog_memory_utilization.png")
+        plt.close(figure)
+
+
+def _rows_as_columns(columns: list[str], rows: list[list[Any]]) -> dict[str, list[Any]]:
+    return {
+        column: [row[index] if index < len(row) else None for row in rows]
+        for index, column in enumerate(columns)
+    }
+
+
+def _is_missing(value: float) -> bool:
+    return math.isnan(value)

--- a/stormlog/cli.py
+++ b/stormlog/cli.py
@@ -17,6 +17,13 @@ try:
     from .phases import summarize_phase_resolution
 except ImportError:  # pragma: no cover - phase package may land in another slice
     summarize_phase_resolution = None  # type: ignore[assignment]
+from .mlflow_integration import (
+    add_mlflow_arguments,
+    ensure_mlflow_available,
+    export_diagnose_bundle_to_mlflow,
+    export_tracking_run_to_mlflow,
+    mlflow_config_from_namespace,
+)
 from .telemetry_sink import TelemetrySinkConfig
 from .utils import (
     _detect_gpu_hardware,
@@ -165,6 +172,22 @@ def _resolve_wandb_config_or_exit(args: argparse.Namespace) -> Any:
 
 def _warn_wandb_export_failure(command_name: str, exc: Exception) -> None:
     print(f"Warning: {command_name} W&B export skipped: {exc}", file=sys.stderr)
+
+
+def _resolve_mlflow_config_or_exit(args: argparse.Namespace) -> Any:
+    config = mlflow_config_from_namespace(args)
+    if not config.enabled:
+        return config
+    try:
+        ensure_mlflow_available(config)
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    return config
+
+
+def _warn_mlflow_export_failure(command_name: str, exc: Exception) -> None:
+    print(f"Warning: {command_name} MLflow export skipped: {exc}", file=sys.stderr)
 
 
 def main() -> None:
@@ -359,6 +382,7 @@ Cookbook:
         help="Maximum retained telemetry sink size in MB (default: 512)",
     )
     add_wandb_arguments(track_parser)
+    add_mlflow_arguments(track_parser)
 
     # Analyze command
     analyze_parser = subparsers.add_parser("analyze", help="Analyze profiling results")
@@ -429,6 +453,7 @@ Cookbook:
         help="Maximum CUDA allocator history entries to retain (default: 100000)",
     )
     add_wandb_arguments(diagnose_parser)
+    add_mlflow_arguments(diagnose_parser)
 
     # Parse arguments
     args = parser.parse_args()
@@ -710,6 +735,7 @@ def cmd_track(args: argparse.Namespace) -> None:
     duration = args.duration
     interval = args.interval
     wandb_config = _resolve_wandb_config_or_exit(args)
+    mlflow_config = _resolve_mlflow_config_or_exit(args)
     job_id = getattr(args, "job_id", None)
     rank = getattr(args, "rank", None)
     local_rank = getattr(args, "local_rank", None)
@@ -904,6 +930,22 @@ def cmd_track(args: argparse.Namespace) -> None:
             print("W&B export completed.")
         except Exception as exc:
             _warn_wandb_export_failure("gpumemprof track", exc)
+
+    if mlflow_config.enabled:
+        try:
+            export_tracking_run_to_mlflow(
+                mlflow_config,
+                command_name="gpumemprof-track",
+                session_summary=tracker.get_session_summary(),
+                stats=stats,
+                events=tracker.get_events(),
+                output_path=args.output,
+                telemetry_sink_dir=getattr(args, "telemetry_sink_dir", None),
+                oom_dump_path=getattr(tracker, "last_oom_dump_path", None),
+            )
+            print("MLflow export completed.")
+        except Exception as exc:
+            _warn_mlflow_export_failure("gpumemprof track", exc)
 
 
 def _json_default(value: Any) -> Any:
@@ -1233,6 +1275,7 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
         return 1
 
     wandb_config = _resolve_wandb_config_or_exit(args)
+    mlflow_config = _resolve_mlflow_config_or_exit(args)
     command_line = " ".join(sys.argv)
     (run_diagnose,) = _import_runtime_symbols(
         ".diagnose", ("run_diagnose",), "The diagnose command"
@@ -1295,6 +1338,17 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             print("W&B export completed.")
         except Exception as exc:
             _warn_wandb_export_failure("gpumemprof diagnose", exc)
+
+    if mlflow_config.enabled:
+        try:
+            export_diagnose_bundle_to_mlflow(
+                mlflow_config,
+                command_name="gpumemprof-diagnose",
+                artifact_dir=artifact_dir,
+            )
+            print("MLflow export completed.")
+        except Exception as exc:
+            _warn_mlflow_export_failure("gpumemprof diagnose", exc)
 
     return int(exit_code)
 

--- a/stormlog/jax/cli.py
+++ b/stormlog/jax/cli.py
@@ -36,6 +36,29 @@ except ImportError:
         return DummyConfig()
 
 
+try:
+    from stormlog.mlflow_integration import (
+        add_mlflow_arguments,
+        ensure_mlflow_available,
+        export_diagnose_bundle_to_mlflow,
+        export_tracking_run_to_mlflow,
+        mlflow_config_from_namespace,
+    )
+
+    MLFLOW_AVAILABLE = True
+except ImportError:
+    MLFLOW_AVAILABLE = False
+
+    def add_mlflow_arguments(parser: Any) -> None:
+        pass
+
+    def mlflow_config_from_namespace(args: Any) -> Any:  # type: ignore[misc]
+        class DummyConfig:
+            enabled = False
+
+        return DummyConfig()
+
+
 from .jax_env import configure_jax_logging
 from .utils import format_memory, get_system_info
 
@@ -144,6 +167,21 @@ def _tracking_memory_capability(results: Any) -> Dict[str, Any]:
             process_memory if isinstance(process_memory, int) else None
         ),
     }
+
+def _resolve_mlflow_config(args: argparse.Namespace) -> Any:
+    config = mlflow_config_from_namespace(args)
+    if not config.enabled:
+        return config
+    try:
+        ensure_mlflow_available(config)
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return None
+    return config
+
+
+def _warn_mlflow_export_failure(command_name: str, exc: Exception) -> None:
+    print(f"Warning: {command_name} MLflow export skipped: {exc}", file=sys.stderr)
 
 
 def cmd_info(args: argparse.Namespace) -> int:
@@ -322,6 +360,9 @@ def cmd_track(args: argparse.Namespace) -> int:
     wandb_config = _resolve_wandb_config(args)
     if wandb_config is None:
         return 1
+    mlflow_config = _resolve_mlflow_config(args)
+    if mlflow_config is None:
+        return 1
 
     print("Starting background memory tracking...")
     job_id = getattr(args, "job_id", None)
@@ -488,6 +529,24 @@ def cmd_track(args: argparse.Namespace) -> int:
         elif wandb_config.enabled:
             print("Warning: W&B is not available.", file=sys.stderr)
 
+        if MLFLOW_AVAILABLE and mlflow_config.enabled:
+            try:
+                export_tracking_run_to_mlflow(
+                    mlflow_config,
+                    command_name="jaxmemprof-track",
+                    session_summary=tracker.get_session_summary(),
+                    stats=final_stats,
+                    events=results.telemetry_events,
+                    output_path=args.output,
+                    telemetry_sink_dir=getattr(args, "telemetry_sink_dir", None),
+                    oom_dump_path=tracker.last_oom_dump_path,
+                )
+                print("MLflow export completed.")
+            except Exception as exc:
+                _warn_mlflow_export_failure("jaxmemprof track", exc)
+        elif mlflow_config.enabled:
+            print("Warning: MLflow is not available.", file=sys.stderr)
+
     return 0
 
 
@@ -505,6 +564,9 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
 
     wandb_config = _resolve_wandb_config(args)
     if wandb_config is None:
+        return 1
+    mlflow_config = _resolve_mlflow_config(args)
+    if mlflow_config is None:
         return 1
 
     command_line = " ".join(sys.argv)
@@ -562,6 +624,19 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             _warn_wandb_export_failure("jaxmemprof diagnose", exc)
     elif wandb_config.enabled:
         print("Warning: W&B is not available.", file=sys.stderr)
+
+    if MLFLOW_AVAILABLE and mlflow_config.enabled:
+        try:
+            export_diagnose_bundle_to_mlflow(
+                mlflow_config,
+                command_name="jaxmemprof-diagnose",
+                artifact_dir=artifact_dir,
+            )
+            print("MLflow export completed.")
+        except Exception as exc:
+            _warn_mlflow_export_failure("jaxmemprof diagnose", exc)
+    elif mlflow_config.enabled:
+        print("Warning: MLflow is not available.", file=sys.stderr)
 
     return exit_code
 
@@ -820,6 +895,7 @@ Cookbook:
         help="Maximum retained OOM dump storage in MB (default: 256)",
     )
     add_wandb_arguments(track_parser)
+    add_mlflow_arguments(track_parser)
 
     # Diagnose command
     diagnose_parser = subparsers.add_parser(
@@ -849,6 +925,7 @@ Cookbook:
         help="Sampling interval for timeline (default: 0.5)",
     )
     add_wandb_arguments(diagnose_parser)
+    add_mlflow_arguments(diagnose_parser)
 
     # Analyze command
     analyze_parser = subparsers.add_parser(

--- a/stormlog/jax/cli.py
+++ b/stormlog/jax/cli.py
@@ -168,6 +168,7 @@ def _tracking_memory_capability(results: Any) -> Dict[str, Any]:
         ),
     }
 
+
 def _resolve_mlflow_config(args: argparse.Namespace) -> Any:
     config = mlflow_config_from_namespace(args)
     if not config.enabled:

--- a/stormlog/mlflow_integration.py
+++ b/stormlog/mlflow_integration.py
@@ -1,0 +1,23 @@
+"""Optional MLflow export helpers for Stormlog outputs (mirror of the W&B exporter)."""
+
+from __future__ import annotations
+
+from ._mlflow.core import (
+    MLFLOW_INSTALL_GUIDANCE,
+    MlflowExportConfig,
+    add_mlflow_arguments,
+    ensure_mlflow_available,
+    mlflow_config_from_namespace,
+)
+from ._mlflow.diagnose import export_diagnose_bundle_to_mlflow
+from ._mlflow.tracking import export_tracking_run_to_mlflow
+
+__all__ = [
+    "MLFLOW_INSTALL_GUIDANCE",
+    "MlflowExportConfig",
+    "add_mlflow_arguments",
+    "ensure_mlflow_available",
+    "export_diagnose_bundle_to_mlflow",
+    "export_tracking_run_to_mlflow",
+    "mlflow_config_from_namespace",
+]

--- a/stormlog/tensorflow/cli.py
+++ b/stormlog/tensorflow/cli.py
@@ -20,6 +20,13 @@ except ImportError:
     TF_AVAILABLE = False
     tf = None
 
+from stormlog.mlflow_integration import (
+    add_mlflow_arguments,
+    ensure_mlflow_available,
+    export_diagnose_bundle_to_mlflow,
+    export_tracking_run_to_mlflow,
+    mlflow_config_from_namespace,
+)
 from stormlog.telemetry import telemetry_event_from_record, telemetry_event_to_dict
 from stormlog.telemetry_sink import TelemetrySinkConfig
 from stormlog.wandb_integration import (
@@ -96,6 +103,22 @@ def _resolve_wandb_config(args: argparse.Namespace) -> Any:
 
 def _warn_wandb_export_failure(command_name: str, exc: Exception) -> None:
     print(f"Warning: {command_name} W&B export skipped: {exc}", file=sys.stderr)
+
+
+def _resolve_mlflow_config(args: argparse.Namespace) -> Any:
+    config = mlflow_config_from_namespace(args)
+    if not config.enabled:
+        return config
+    try:
+        ensure_mlflow_available(config)
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return None
+    return config
+
+
+def _warn_mlflow_export_failure(command_name: str, exc: Exception) -> None:
+    print(f"Warning: {command_name} MLflow export skipped: {exc}", file=sys.stderr)
 
 
 def cmd_info(args: argparse.Namespace) -> int:
@@ -286,6 +309,9 @@ def cmd_track(args: argparse.Namespace) -> int:
     wandb_config = _resolve_wandb_config(args)
     if wandb_config is None:
         return 1
+    mlflow_config = _resolve_mlflow_config(args)
+    if mlflow_config is None:
+        return 1
 
     print("Starting background memory tracking...")
     job_id = getattr(args, "job_id", None)
@@ -423,6 +449,22 @@ def cmd_track(args: argparse.Namespace) -> int:
                 print("W&B export completed.")
             except Exception as exc:
                 _warn_wandb_export_failure("tfmemprof track", exc)
+
+        if mlflow_config.enabled:
+            try:
+                export_tracking_run_to_mlflow(
+                    mlflow_config,
+                    command_name="tfmemprof-track",
+                    session_summary=tracker.get_session_summary(),
+                    stats=final_stats,
+                    events=results.events,
+                    output_path=args.output,
+                    telemetry_sink_dir=getattr(args, "telemetry_sink_dir", None),
+                    oom_dump_path=None,
+                )
+                print("MLflow export completed.")
+            except Exception as exc:
+                _warn_mlflow_export_failure("tfmemprof track", exc)
 
     return 0
 
@@ -587,6 +629,9 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
     wandb_config = _resolve_wandb_config(args)
     if wandb_config is None:
         return 1
+    mlflow_config = _resolve_mlflow_config(args)
+    if mlflow_config is None:
+        return 1
 
     command_line = " ".join(sys.argv)
     try:
@@ -639,6 +684,17 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
             print("W&B export completed.")
         except Exception as exc:
             _warn_wandb_export_failure("tfmemprof diagnose", exc)
+
+    if mlflow_config.enabled:
+        try:
+            export_diagnose_bundle_to_mlflow(
+                mlflow_config,
+                command_name="tfmemprof-diagnose",
+                artifact_dir=artifact_dir,
+            )
+            print("MLflow export completed.")
+        except Exception as exc:
+            _warn_mlflow_export_failure("tfmemprof diagnose", exc)
 
     return exit_code
 
@@ -763,6 +819,7 @@ Cookbook:
         help="Maximum retained telemetry sink size in MB (default: 512)",
     )
     add_wandb_arguments(track_parser)
+    add_mlflow_arguments(track_parser)
 
     # Analyze command
     analyze_parser = subparsers.add_parser("analyze", help="Analyze profiling results")
@@ -810,6 +867,7 @@ Cookbook:
         help="Sampling interval for timeline (default: 0.5)",
     )
     add_wandb_arguments(diagnose_parser)
+    add_mlflow_arguments(diagnose_parser)
 
     args = parser.parse_args()
 

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -314,6 +314,12 @@ def test_export_tracking_run_logs_metrics_tables_and_artifacts(
     assert fake_mlflow.metrics["stormlog_chart_point_count"] == [(3.0, None)]
     assert "stormlog_backend" not in fake_mlflow.metrics  # strings go to tags
     assert fake_mlflow.tags["stormlog_backend"] == "cuda"
+    assert fake_mlflow.tags["stormlog_rank"] == "2"
+    assert fake_mlflow.tags["stormlog_local_rank"] == "0"
+    assert fake_mlflow.tags["stormlog_world_size"] == "8"
+    assert "stormlog_rank" not in fake_mlflow.metrics
+    assert "stormlog_local_rank" not in fake_mlflow.metrics
+    assert "stormlog_world_size" not in fake_mlflow.metrics
     assert fake_mlflow.tags["stormlog_attribution_html_file"] == (
         "cuda_allocator_state_history_annotated.html"
     )
@@ -582,7 +588,33 @@ def test_tracking_resumes_existing_run_id(
 
     assert fake_mlflow.start_kwargs is not None
     assert fake_mlflow.start_kwargs["run_id"] == "existing-run-1"
-    assert fake_mlflow.start_kwargs["run_name"].startswith("stormlog-track-")
+    assert "run_name" not in fake_mlflow.start_kwargs
+    assert fake_mlflow.end_calls == 1
+
+
+def test_tracking_resume_forwards_explicit_run_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(
+            Namespace(
+                mlflow=True,
+                mlflow_run_id="existing-run-1",
+                mlflow_run_name="explicit rename",
+            )
+        ),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[],
+    )
+
+    assert fake_mlflow.start_kwargs is not None
+    assert fake_mlflow.start_kwargs["run_id"] == "existing-run-1"
+    assert fake_mlflow.start_kwargs["run_name"] == "explicit rename"
     assert fake_mlflow.end_calls == 1
 
 

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -1,0 +1,710 @@
+from __future__ import annotations
+
+import builtins
+import json
+import pickle
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+import stormlog.cuda_native_debug as native_debug
+from stormlog.mlflow_integration import (
+    ensure_mlflow_available,
+    export_diagnose_bundle_to_mlflow,
+    export_tracking_run_to_mlflow,
+    mlflow_config_from_namespace,
+)
+from stormlog.session import create_session_summary
+
+
+class _FakeRun:
+    """Opaque run handle; the fluent API operates on the active run."""
+
+
+class _FakeMlflowModule(ModuleType):
+    def __init__(self) -> None:
+        super().__init__("mlflow")
+        self.active: _FakeRun | None = None
+        self.tracking_uri: str | None = None
+        self.experiment: str | None = None
+        self.start_kwargs: dict[str, Any] | None = None
+        self.tags: dict[str, str] = {}
+        self.metrics: dict[str, list[tuple[float, int | None]]] = {}
+        self.texts: list[tuple[str, str]] = []
+        self.tables: list[tuple[dict[str, list[Any]], str]] = []
+        self.artifacts: list[tuple[str, str | None]] = []
+        self.directories: list[tuple[str, str | None]] = []
+        self.figures: list[tuple[Any, str]] = []
+        self.end_calls = 0
+
+    def active_run(self) -> _FakeRun | None:
+        return self.active
+
+    def set_tracking_uri(self, uri: str) -> None:
+        self.tracking_uri = uri
+
+    def set_experiment(self, name: str) -> None:
+        self.experiment = name
+
+    def start_run(self, **kwargs: Any) -> _FakeRun:
+        self.start_kwargs = kwargs
+        run = _FakeRun()
+        self.active = run
+        return run
+
+    def set_tags(self, tags: dict[str, str]) -> None:
+        self.tags.update(tags)
+
+    def set_tag(self, key: str, value: str) -> None:
+        self.tags[key] = value
+
+    def log_metric(self, key: str, value: float) -> None:
+        self.metrics.setdefault(key, []).append((value, None))
+
+    def log_metrics(self, metrics: dict[str, float], step: int | None = None) -> None:
+        for key, value in metrics.items():
+            self.metrics.setdefault(key, []).append((value, step))
+
+    def log_text(self, text: str, artifact_file: str) -> None:
+        self.texts.append((text, artifact_file))
+
+    def log_table(self, data: dict[str, list[Any]], artifact_file: str) -> None:
+        self.tables.append((data, artifact_file))
+
+    def log_artifact(self, local_path: str, artifact_path: str | None = None) -> None:
+        self.artifacts.append((local_path, artifact_path))
+
+    def log_artifacts(self, local_dir: str, artifact_path: str | None = None) -> None:
+        self.directories.append((local_dir, artifact_path))
+
+    def log_figure(self, figure: Any, artifact_file: str) -> None:
+        self.figures.append((figure, artifact_file))
+
+    def end_run(self) -> None:
+        self.end_calls += 1
+        self.active = None
+
+
+def _install_fake_mlflow(monkeypatch: pytest.MonkeyPatch) -> _FakeMlflowModule:
+    fake = _FakeMlflowModule()
+    monkeypatch.setitem(sys.modules, "mlflow", fake)
+    return fake
+
+
+def _block_matplotlib(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "matplotlib", None)
+
+
+def test_mlflow_config_from_namespace_collects_explicit_values() -> None:
+    config = mlflow_config_from_namespace(
+        Namespace(
+            mlflow=True,
+            mlflow_tracking_uri="file:./mlruns",
+            mlflow_experiment="stormlog-tests",
+            mlflow_run_id="run-123",
+            mlflow_run_name="track smoke",
+            mlflow_group="job-42",
+            mlflow_job_type="stormlog-track",
+            mlflow_log_artifacts=True,
+            mlflow_log_attribution=True,
+        )
+    )
+
+    assert config.enabled is True
+    assert config.tracking_uri == "file:./mlruns"
+    assert config.experiment == "stormlog-tests"
+    assert config.run_id == "run-123"
+    assert config.run_name == "track smoke"
+    assert config.group == "job-42"
+    assert config.job_type == "stormlog-track"
+    assert config.log_tables is True
+    assert config.log_artifacts is True
+    assert config.log_attribution is True
+
+
+def test_ensure_mlflow_available_reports_optional_dependency_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def _blocked_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "mlflow" or name.startswith("mlflow."):
+            raise ModuleNotFoundError("No module named 'mlflow'", name="mlflow")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    with pytest.raises(ImportError, match=r"stormlog\[mlflow\]"):
+        ensure_mlflow_available(mlflow_config_from_namespace(Namespace(mlflow=True)))
+
+
+def test_export_tracking_run_logs_metrics_tables_and_artifacts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+
+    output_path = tmp_path / "track.json"
+    output_path.write_text("{}", encoding="utf-8")
+
+    sink_dir = tmp_path / "sink"
+    sink_dir.mkdir()
+    (sink_dir / "manifest.json").write_text("{}", encoding="utf-8")
+
+    oom_dir = tmp_path / "oom"
+    oom_dir.mkdir()
+    (oom_dir / "cuda_allocator_state_history_annotated.html").write_text(
+        "<html><body>stormlog attribution</body></html>",
+        encoding="utf-8",
+    )
+    with (oom_dir / native_debug.SNAPSHOT_PICKLE_FILENAME).open("wb") as handle:
+        pickle.dump(
+            {
+                "segments": [
+                    {
+                        "address": 4096,
+                        "segment_type": "large",
+                        "total_size": 128,
+                        "allocated_size": 64,
+                        "active_size": 64,
+                        "blocks": [
+                            {
+                                "address": 8192,
+                                "size": 64,
+                                "state": "active_allocated",
+                                "frames": [],
+                            }
+                        ],
+                    }
+                ],
+                "device_traces": [
+                    [
+                        {
+                            "action": "alloc",
+                            "addr": 8192,
+                            "size": 64,
+                            "time_us": 100,
+                            "frames": [],
+                        }
+                    ]
+                ],
+            },
+            handle,
+        )
+    (oom_dir / "cuda_tensor_attribution.json").write_text(
+        json.dumps(
+            {
+                "attributed_storage_pointers": [
+                    {
+                        "storage_ptr": "0x1",
+                        "storage_ptr_int": 8192,
+                        "names": ["model.layer.weight"],
+                        "tensor_count": 1,
+                        "tensors": [
+                            {
+                                "shape": [4, 4],
+                                "dtype": "torch.float32",
+                                "size_bytes": 64,
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    session_summary = create_session_summary(
+        source="stormlog.tracker",
+        session_id="session-12345678",
+        job_id="train-42",
+        rank=2,
+        local_rank=0,
+        world_size=8,
+    )
+    config = mlflow_config_from_namespace(
+        Namespace(
+            mlflow=True,
+            mlflow_tracking_uri="file:./mlruns",
+            mlflow_experiment="stormlog-tests",
+            mlflow_group=None,
+            mlflow_job_type=None,
+            mlflow_log_artifacts=True,
+            mlflow_log_attribution=True,
+        )
+    )
+
+    export_tracking_run_to_mlflow(
+        config,
+        command_name="stormlog-track",
+        session_summary=session_summary,
+        stats={
+            "backend": "cuda",
+            "peak_memory": 4096,
+            "total_events": 3,
+            "alert_count": 1,
+            "tracking_duration_seconds": 5.0,
+            "collector_health_status": "healthy",
+            "history_dropped_events": 0,
+        },
+        events=[
+            {
+                "timestamp": 9.5,
+                "event_type": "allocation",
+                "context": "warmup",
+                "memory_allocated": 1024,
+                "memory_reserved": 2048,
+                "memory_change": 1024,
+                "device_used": 2048,
+                "device_total": 8192,
+                "job_id": "train-42",
+                "rank": 2,
+            },
+            {
+                "timestamp": 10.0,
+                "event_type": "warning",
+                "context": "memory high",
+                "memory_allocated": 2048,
+                "memory_reserved": 4096,
+                "memory_change": 512,
+                "device_used": 4096,
+                "device_total": 8192,
+                "job_id": "train-42",
+                "rank": 2,
+            },
+            {
+                "timestamp": 10.5,
+                "event_type": "peak",
+                "context": "peak memory",
+                "memory_allocated": 3072,
+                "memory_reserved": 4096,
+                "memory_change": 1024,
+                "device_used": 5120,
+                "device_total": 8192,
+                "job_id": "train-42",
+                "rank": 2,
+            },
+        ],
+        output_path=output_path,
+        telemetry_sink_dir=sink_dir,
+        oom_dump_path=oom_dir,
+    )
+
+    assert fake_mlflow.tracking_uri == "file:./mlruns"
+    assert fake_mlflow.experiment == "stormlog-tests"
+    assert fake_mlflow.start_kwargs is not None
+    assert fake_mlflow.start_kwargs["run_name"].startswith("stormlog-track-")
+    assert fake_mlflow.tags["stormlog_session_id"] == "session-12345678"
+    assert fake_mlflow.tags["stormlog_group"] == "train-42"
+    assert fake_mlflow.tags["stormlog_job_type"] == "stormlog-track"
+    assert fake_mlflow.end_calls == 1
+
+    assert fake_mlflow.metrics["stormlog_peak_memory_bytes"] == [(4096.0, None)]
+    assert fake_mlflow.metrics["stormlog_total_events"] == [(3.0, None)]
+    assert fake_mlflow.metrics["stormlog_chart_point_count"] == [(3.0, None)]
+    assert "stormlog_backend" not in fake_mlflow.metrics  # strings go to tags
+    assert fake_mlflow.tags["stormlog_backend"] == "cuda"
+    assert fake_mlflow.tags["stormlog_attribution_html_file"] == (
+        "cuda_allocator_state_history_annotated.html"
+    )
+
+    timeline_steps = {
+        step
+        for values in fake_mlflow.metrics.values()
+        for _, step in values
+        if step is not None
+    }
+    assert timeline_steps == {0, 1, 2}
+    assert len(fake_mlflow.metrics["stormlog_timeline_allocated_bytes"]) == 3
+
+    table_files = {artifact_file for _, artifact_file in fake_mlflow.tables}
+    assert "stormlog_alerts.json" in table_files
+    assert "stormlog_memory_timeline.json" in table_files
+    assert "stormlog_tensor_attribution.json" in table_files
+
+    text_files = {artifact_file for _, artifact_file in fake_mlflow.texts}
+    assert "stormlog_tracking_dashboard.html" in text_files
+    assert "stormlog_attribution_preview.html" in text_files
+    attribution_text = next(
+        text
+        for text, artifact_file in fake_mlflow.texts
+        if artifact_file == "stormlog_attribution_preview.html"
+    )
+    assert "Stormlog GPU Attribution Preview" in attribution_text
+    assert "<script>" not in attribution_text
+
+    artifact_paths = {artifact_path for _, artifact_path in fake_mlflow.artifacts}
+    assert "stormlog-track-output-session-12345678" in artifact_paths
+    assert "stormlog-tracking-dashboard-session-12345678" in artifact_paths
+    assert "stormlog-attribution-session-12345678" in artifact_paths
+    assert {directory_path for directory_path, _ in fake_mlflow.directories} == {
+        str(sink_dir),
+        str(oom_dir),
+    }
+    assert fake_mlflow.figures == []
+
+
+def test_export_diagnose_bundle_logs_summary_and_artifact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+
+    artifact_dir = tmp_path / "stormlog-diagnose"
+    artifact_dir.mkdir()
+    session_summary = create_session_summary(
+        source="gpumemprof diagnose",
+        session_id="diag-12345678",
+        job_id="job-7",
+    )
+    (artifact_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "session": {
+                    "session_id": session_summary.session_id,
+                    "status": session_summary.status,
+                    "started_at_ns": session_summary.started_at_ns,
+                    "ended_at_ns": session_summary.ended_at_ns,
+                    "host": session_summary.host,
+                    "pid": session_summary.pid,
+                    "job_id": session_summary.job_id,
+                    "rank": session_summary.rank,
+                    "local_rank": session_summary.local_rank,
+                    "world_size": session_summary.world_size,
+                    "source": session_summary.source,
+                },
+                "risk_detected": True,
+                "exit_code": 2,
+                "native_history_enabled": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_dir / "diagnostic_summary.json").write_text(
+        json.dumps(
+            {
+                "allocated_bytes": 1024,
+                "reserved_bytes": 2048,
+                "peak_bytes": 4096,
+                "total_bytes": 8192,
+                "utilization_ratio": 0.8,
+                "fragmentation_ratio": 0.2,
+                "num_ooms": 1,
+                "risk_flags": {
+                    "oom_occurred": True,
+                    "high_utilization": False,
+                    "fragmentation_warning": False,
+                },
+                "suggestions": ["Reduce batch size"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_dir / "cuda_allocator_state_history_annotated.html").write_text(
+        "<html><body>attribution</body></html>",
+        encoding="utf-8",
+    )
+    (artifact_dir / "cuda_tensor_attribution.json").write_text(
+        json.dumps({"attributed_storage_pointers": []}),
+        encoding="utf-8",
+    )
+
+    config = mlflow_config_from_namespace(
+        Namespace(
+            mlflow=True,
+            mlflow_experiment="stormlog-diag",
+            mlflow_log_artifacts=True,
+            mlflow_log_attribution=True,
+        )
+    )
+
+    export_diagnose_bundle_to_mlflow(
+        config,
+        command_name="stormlog-diagnose",
+        artifact_dir=artifact_dir,
+    )
+
+    assert fake_mlflow.experiment == "stormlog-diag"
+    assert fake_mlflow.end_calls == 1
+    assert fake_mlflow.metrics["stormlog_allocated_bytes"] == [(1024.0, None)]
+    assert fake_mlflow.tags["stormlog_artifact_dir"] == "stormlog-diagnose"
+    assert fake_mlflow.tags["stormlog_session_id"] == "diag-12345678"
+    assert fake_mlflow.tags["stormlog_attribution_html_file"] == (
+        "cuda_allocator_state_history_annotated.html"
+    )
+    assert {artifact_file for _, artifact_file in fake_mlflow.tables} == {
+        "stormlog_diagnostic_suggestions.json"
+    }
+    assert {artifact_file for _, artifact_file in fake_mlflow.texts} == {
+        "stormlog_attribution_preview.html"
+    }
+    assert fake_mlflow.directories == [
+        (str(artifact_dir), "stormlog-diagnose-diag-12345678")
+    ]
+
+
+def test_tracking_visual_artifacts_respect_log_artifacts_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(Namespace(mlflow=True)),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[
+            {
+                "timestamp": 1.0,
+                "event_type": "sample",
+                "memory_allocated": 128,
+                "memory_reserved": 256,
+                "device_used": 256,
+                "device_total": 1024,
+            }
+        ],
+    )
+
+    assert fake_mlflow.artifacts == []
+    assert fake_mlflow.directories == []
+    assert "stormlog_tracking_dashboard_file" not in fake_mlflow.tags
+    assert {artifact_file for _, artifact_file in fake_mlflow.texts} == {
+        "stormlog_tracking_dashboard.html"
+    }
+
+
+def test_attribution_inline_logging_respects_log_artifacts_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+
+    attribution_dir = tmp_path / "attribution"
+    attribution_dir.mkdir()
+    (attribution_dir / native_debug.TRACE_HTML_ANNOTATED_FILENAME).write_text(
+        "<html><body>stormlog attribution</body></html>",
+        encoding="utf-8",
+    )
+    (attribution_dir / native_debug.TENSOR_ATTRIBUTION_FILENAME).write_text(
+        json.dumps(
+            {
+                "storage_pointer_count": 1,
+                "attributed_storage_pointers": [
+                    {
+                        "storage_ptr": "0x1",
+                        "storage_ptr_int": 8192,
+                        "names": ["model.layer.weight"],
+                        "tensor_count": 1,
+                        "tensors": [
+                            {
+                                "shape": [4, 4],
+                                "dtype": "torch.float32",
+                                "size_bytes": 64,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(
+            Namespace(
+                mlflow=True,
+                mlflow_log_artifacts=False,
+                mlflow_log_attribution=True,
+            )
+        ),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[],
+        attribution_bundle_dir=attribution_dir,
+    )
+
+    assert fake_mlflow.artifacts == []
+    assert {artifact_file for _, artifact_file in fake_mlflow.texts} == {
+        "stormlog_attribution_preview.html"
+    }
+    assert {artifact_file for _, artifact_file in fake_mlflow.tables} == {
+        "stormlog_tensor_attribution.json"
+    }
+
+
+def test_export_uses_active_mlflow_run_without_creating_another(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+    fake_mlflow.active = _FakeRun()
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(Namespace(mlflow=True)),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[],
+    )
+
+    assert fake_mlflow.start_kwargs is None
+    assert fake_mlflow.end_calls == 0
+    assert fake_mlflow.metrics["stormlog_peak_memory_bytes"] == [(128.0, None)]
+
+
+def test_tracking_resumes_existing_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    _block_matplotlib(monkeypatch)
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(
+            Namespace(mlflow=True, mlflow_run_id="existing-run-1")
+        ),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[],
+    )
+
+    assert fake_mlflow.start_kwargs is not None
+    assert fake_mlflow.start_kwargs["run_id"] == "existing-run-1"
+    assert fake_mlflow.start_kwargs["run_name"].startswith("stormlog-track-")
+    assert fake_mlflow.end_calls == 1
+
+
+def test_memory_plots_are_skipped_when_matplotlib_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    monkeypatch.setitem(sys.modules, "matplotlib", None)
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(Namespace(mlflow=True)),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[
+            {
+                "timestamp": 1.0,
+                "event_type": "sample",
+                "memory_allocated": 128,
+                "memory_reserved": 256,
+                "device_used": 256,
+                "device_total": 1024,
+            },
+            {
+                "timestamp": 2.0,
+                "event_type": "sample",
+                "memory_allocated": 256,
+                "memory_reserved": 512,
+                "device_used": 512,
+                "device_total": 1024,
+            },
+        ],
+    )
+
+    assert fake_mlflow.figures == []
+    assert {artifact_file for _, artifact_file in fake_mlflow.texts} == {
+        "stormlog_tracking_dashboard.html"
+    }
+
+
+class _FakeFigure:
+    pass
+
+
+class _FakePyplot:
+    def __init__(self) -> None:
+        self.figures: list[_FakeFigure] = []
+
+    def figure(self, figsize: tuple[float, float] | None = None) -> _FakeFigure:
+        figure = _FakeFigure()
+        self.figures.append(figure)
+        return figure
+
+    def plot(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def xlabel(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def ylabel(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def title(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def legend(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def tight_layout(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def close(self, figure: _FakeFigure) -> None:
+        return None
+
+
+class _FakeMatplotlibModule(ModuleType):
+    def __init__(self, pyplot: _FakePyplot) -> None:
+        super().__init__("matplotlib")
+        self.pyplot = pyplot
+        self.backend: str | None = None
+
+    def use(self, backend: str) -> None:
+        self.backend = backend
+
+
+def test_memory_plots_are_logged_when_matplotlib_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_mlflow = _install_fake_mlflow(monkeypatch)
+    pyplot = _FakePyplot()
+    fake_matplotlib = _FakeMatplotlibModule(pyplot)
+    monkeypatch.setitem(sys.modules, "matplotlib", fake_matplotlib)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot)
+
+    export_tracking_run_to_mlflow(
+        mlflow_config_from_namespace(Namespace(mlflow=True)),
+        command_name="stormlog-track",
+        session_summary=create_session_summary(source="stormlog.tracker"),
+        stats={"peak_memory": 128},
+        events=[
+            {
+                "timestamp": 1.0,
+                "event_type": "sample",
+                "memory_allocated": 128,
+                "memory_reserved": 256,
+                "device_used": 256,
+                "device_total": 1024,
+            },
+            {
+                "timestamp": 2.0,
+                "event_type": "sample",
+                "memory_allocated": 256,
+                "memory_reserved": 512,
+                "device_used": 512,
+                "device_total": 1024,
+            },
+        ],
+    )
+
+    assert fake_matplotlib.backend == "Agg"
+    figure_files = {artifact_file for _, artifact_file in fake_mlflow.figures}
+    assert figure_files == {
+        "stormlog_memory_timeline.png",
+        "stormlog_memory_utilization.png",
+    }


### PR DESCRIPTION
## Summary

Adds an optional **MLflow export integration** to Stormlog that mirrors the existing W&B exporter 1:1 — same config surface, same run lifecycle, same tracking/diagnose/attribution outputs — so teams on MLflow get the same Stormlog visibility as teams on W&B.

### What it would take / what was built (wandb → mlflow mapping)

| W&B exporter | MLflow equivalent |
| --- | --- |
| `wandb.init(project, entity, mode)` | `mlflow.set_tracking_uri` + `mlflow.set_experiment` + `mlflow.start_run` |
| `run.summary.update(payload)` | `mlflow.log_metric` (numbers) + `mlflow.set_tag` (strings/bools) |
| `run.log({k: wandb.Table(...)})` | `mlflow.log_table(data, artifact_file="*.json")` |
| `run.log({k: wandb.Html(...)})` | `mlflow.log_text(html, artifact_file="*.html")` |
| `run.log({k: wandb.plot.line_series(...)})` | `mlflow.log_figure` (matplotlib, optional dep) |
| `wandb.Artifact` / `run.log_artifact` | `mlflow.log_artifact` / `mlflow.log_artifacts` |
| active-run detection (`wandb.run`) | `mlflow.active_run()` |
| resume via `wandb.init(id=..., resume=...)` | `mlflow.start_run(run_id=...)` |
| `run.finish()` | `mlflow.end_run()` |

### Changes

- **New public API** `stormlog.mlflow_integration` + internal `stormlog._mlflow` package (`core`, `tracking`, `diagnose`, `attribution`) mirroring `stormlog._wandb`. Backend-agnostic helpers (timeline math, dashboard HTML, attribution preview, tensor-table extraction) are reused from the W&B exporter so both integrations stay in sync.
- **CLI wiring**: `--mlflow*` flags on `gpumemprof`, `jaxmemprof`, and `tfmemprof` `track`/`diagnose` commands:
  - `--mlflow`, `--mlflow-tracking-uri`, `--mlflow-experiment`, `--mlflow-run-id`, `--mlflow-run-name`, `--mlflow-group`, `--mlflow-job-type`, `--mlflow-log-artifacts`, `--mlflow-log-attribution`
  - Fail-fast with install guidance when `stormlog[mlflow]` is missing.
- **Packaging**: new `mlflow` extra (`mlflow>=2.4.0`), included in the `all` extra; mypy ignore override for the optional import.
- **Exports**: session metrics/tags, alert + memory-timeline tables, tracking dashboard HTML, matplotlib timeline/utilization plots (skipped gracefully when matplotlib is absent), attribution preview HTML + top-tensor table, and output/telemetry-sink/oom/attribution artifacts.
- **Tests**: `tests/test_mlflow_integration.py` (10 tests) with a fake `mlflow` module covering config parsing, tracking/diagnose exports, tables/HTML/plots, artifact logging flags, active-run reuse, and run resume.
- **Docs**: `docs/examples.md` (new "Exporting to MLflow" section + offline `file:./mlruns` equivalent), `docs/cookbook/pytorch.md` (MLflow alternative note in the L4 smoke recipe), `docs/testing.md` (optional MLflow export check). API reference is picked up automatically by the Sphinx autosummary. The CHANGELOG was deliberately not updated — feature PRs in this repo only touch it at release time.

### Validation

- `tests/test_mlflow_integration.py`, `tests/test_wandb_integration.py`, `tests/test_packaging_contracts.py`, `tests/test_docs_regressions.py` + full CLI suites: **194 passed**.
- black / isort / flake8 / mypy (pre-commit) all clean.
- Full-suite run: only pre-existing env failures (missing `torch`/`jsonschema` in the local venv) — same failures reproduce on clean `release/dev`.
